### PR TITLE
Use ajax api request to get market hash.

### DIFF
--- a/ASF-STM.user.js
+++ b/ASF-STM.user.js
@@ -1756,7 +1756,6 @@
             }
         }
     } else {
-
         //Code below is a heavily modified version of SteamTrade Matcher Userscript by Tithen-Firion
         //Original can be found on https://github.com/Tithen-Firion/STM-UserScript
 

--- a/ASF-STM.user.js
+++ b/ASF-STM.user.js
@@ -950,7 +950,7 @@
                                         hash: xhr.response.badgedata.rgCards[i].markethash,
                                         count: xhr.response.badgedata.rgCards[i].owned,
                                         iconUrl: xhr.response.badgedata.rgCards[i].imgurl,
-                                        number: i
+                                        number: i,
                                     };
                                     debugPrint(JSON.stringify(newcard));
                                     myBadges[index].cards.push(newcard);
@@ -968,14 +968,14 @@
                                 );
                                 return;
                             } else {
-                                debugPrint("less than 5 cards in a badge - something is wrong")
+                                debugPrint("less than 5 cards in a badge - something is wrong");
                                 debugPrint(JSON.stringify(xhr.response));
                                 errors++;
                             }
                         } else {
                             updateMessage("Error getting own badge data, badge: " + myBadges[index].appId);
                             if (xhr.response != undefined) {
-                                debugPrint("eresult = "+xhr.response.eresult);
+                                debugPrint("eresult = " + xhr.response.eresult);
                             }
                             hideThrobber();
                             enableButton();
@@ -1083,7 +1083,7 @@
             updateMessage("No cards to match");
             enableButton();
             let stopButton = document.getElementById("asf_stm_stop");
-                stopButton.parentNode.removeChild(stopButton);
+            stopButton.parentNode.removeChild(stopButton);
             return;
         } else {
             SaveParams();
@@ -1107,11 +1107,12 @@
             return;
         }
 
-        if (((bots.Result[userindex].MatchEverything && !globalSettings.anyBots) ||
+        if (
+            (bots.Result[userindex].MatchEverything && !globalSettings.anyBots) ||
             (!bots.Result[userindex].MatchEverything && !globalSettings.fairBots) ||
-             bots.Result[userindex].TotalInventoryCount < globalSettings.botMinItems ||
-             (globalSettings.botMaxItems > 0 && bots.Result[userindex].TotalInventoryCount > globalSettings.botMaxItems) ||
-             blacklist.includes(bots.Result[userindex].SteamID))
+            bots.Result[userindex].TotalInventoryCount < globalSettings.botMinItems ||
+            (globalSettings.botMaxItems > 0 && bots.Result[userindex].TotalInventoryCount > globalSettings.botMaxItems) ||
+            blacklist.includes(bots.Result[userindex].SteamID)
         ) {
             debugPrint("Ignoring bot " + bots.Result[userindex].SteamID);
             debugPrint(bots.Result[userindex].MatchEverything && !globalSettings.anyBots);
@@ -1179,7 +1180,7 @@
                                 }
                             });
                             name = name.trim();
-                            let markethash = myBadges[index].cards.find(card => card.number === i).hash;
+                            let markethash = myBadges[index].cards.find((card) => card.number === i).hash;
                             let icon = badgeCards[i].querySelector(".gamecard").src.trim();
                             let newcard = {
                                 item: name,
@@ -1302,7 +1303,6 @@
                 globalSettings.weblimiter,
             );
         });
-
     }
 
     function getBadges(page) {
@@ -1626,7 +1626,7 @@
             method: "GET",
             url: requestUrl,
             headers: {
-                "User-Agent": "ASF-STM/" + GM_info.version
+                "User-Agent": "ASF-STM/" + GM_info.version,
             },
             onload: function (response) {
                 if (response.status !== 200) {
@@ -1795,7 +1795,7 @@
                 inv = inv.rgInventory;
                 Object.keys(inv).forEach(function (item) {
                     // add all matching cards to temporary dict
-                    index = requestedCards.findIndex((elem) =>(elem == inv[item].market_hash_name));
+                    index = requestedCards.findIndex((elem) => elem == inv[item].market_hash_name);
                     if (index > -1) {
                         if (tmpCards[requestedCards[index]] === undefined) {
                             tmpCards[requestedCards[index]] = [];

--- a/ASF-STM.user.js
+++ b/ASF-STM.user.js
@@ -10,7 +10,7 @@
 // @match           *://steamcommunity.com/profiles/*/badges
 // @match           *://steamcommunity.com/profiles/*/badges/
 // @match           *://steamcommunity.com/tradeoffer/new/*source=asfstm*
-// @version         4.0
+// @version         4.1
 // @connect         asf.justarchi.net
 // @grant           GM.xmlHttpRequest
 // @grant           GM_addStyle
@@ -488,7 +488,7 @@
         if (tradeParams.cardNames === undefined) {
             tradeParams.cardNames = Array.from(cardNames);
         }
-        console.warn(JSON.stringify(tradeParams.filter));
+        debugPrint(JSON.stringify(tradeParams.filter));
         localStorage.setItem("Ryzhehvost.ASF.STM.Params", JSON.stringify(tradeParams));
     }
 
@@ -1575,6 +1575,11 @@
         maxPages = 1;
         stop = false;
         myBadges.length = 0;
+        cardNames = new Set();
+        tradeParams = {
+            matches: {},
+            filter: [],
+        };
         getBadges(1);
     }
 
@@ -1751,6 +1756,7 @@
             }
         }
     } else {
+
         //Code below is a heavily modified version of SteamTrade Matcher Userscript by Tithen-Firion
         //Original can be found on https://github.com/Tithen-Firion/STM-UserScript
 
@@ -1861,6 +1867,13 @@
                 unsafeWindow.CTradeOfferStateManager.ConfirmTradeOffer();
             }
 
+            let notif = document.createElement("span");
+            notif.setAttribute("style", "color:#00FF00; opacity:0; transition: opacity 3s;");
+            notif.appendChild(document.createTextNode("(All cards added successfully)"));
+            let anchor = document.getElementsByClassName("trade_partner_headline")[0];
+            anchor.appendChild(notif);
+            window.getComputedStyle(notif).opacity;
+            notif.style.opacity = 1;
             debugPrint("everything done");
         }
 
@@ -1937,6 +1950,7 @@
                 if (matches === undefined) {
                     throw new Error("no matches with this partner");
                 }
+                debugPrint(JSON.stringify(matches));
                 for (let i = 0; i < filter.length; i++) {
                     let appid = filter[i];
 
@@ -1944,10 +1958,12 @@
                         //can happen, filter is just allowed appids, not necessaryly available on this bot.
                         debugPrint("no such appid in matches: " + appid);
                     } else {
+                        debugPrint("adding matches for appid: " + appid);
                         Cards[0] = Cards[0].concat(matches[appid].send.map((card) => decodeURIComponent(params.cardNames[card])));
                         Cards[1] = Cards[1].concat(matches[appid].receive.map((card) => decodeURIComponent(params.cardNames[card])));
                     }
                 }
+                debugPrint(JSON.stringify(Cards));
 
                 if (Cards[0].length !== Cards[1].length) {
                     unsafeWindow.ShowAlertDialog("Different items amount", "You've requested " + (Cards[0].length > Cards[1].length ? "less" : "more") + " items than you give. Script aborting.");

--- a/ASF-STM.user.js
+++ b/ASF-STM.user.js
@@ -15,6 +15,8 @@
 // @grant           GM.xmlHttpRequest
 // @grant           GM_addStyle
 // @grant           GM_xmlhttpRequest
+// @downloadURL https://update.greasyfork.org/scripts/404754/ASF%20STM.user.js
+// @updateURL https://update.greasyfork.org/scripts/404754/ASF%20STM.meta.js
 // ==/UserScript==
 
 (function () {
@@ -750,7 +752,7 @@
             }
             for (let c = 0; c < itemsToSend[i].cards.length; c++) {
                 for (let a = 0; a < itemsToSend[i].cards[c].count; a++) {
-                    let cardID = tradeParams.cardNames.indexOf(itemsToSend[i].cards[c].iconUrl.substring(itemsToSend[i].cards[c].iconUrl.length - 5) + "." + itemsToSend[i].appId + "-" + itemsToSend[i].cards[c].item);
+                    let cardID = tradeParams.cardNames.indexOf(itemsToSend[i].cards[c].hash);
                     tradeParams.matches[partner][itemsToSend[i].appId].send.push(cardID);
                 }
             }
@@ -904,6 +906,191 @@
         }
     }
 
+    function GetOwnCards(index) {
+        debugPrint("GetOwnCards " + index);
+
+        if (index === 0) {
+            for (let i = 0; i < myBadges.length; i++) {
+                myBadges[i].cards.length = 0;
+            }
+        }
+        if (index < myBadges.length) {
+            let profileLink;
+            profileLink = myProfileLink;
+            updateMessage("Getting our data for badge " + (index + 1) + " of " + myBadges.length);
+            updateProgress(index, myBadges.length);
+
+            let url = "https://steamcommunity.com/" + profileLink + "/gamecards/" + myBadges[index].appId;
+            let xhr = new XMLHttpRequest();
+            xhr.open("GET", url, true);
+            xhr.responseType = "json";
+            // eslint-disable-next-line
+            xhr.onload = function () {
+                if (stop) {
+                    updateMessage("Interrupted by user");
+                    hideThrobber();
+                    enableButton();
+                    let stopButton = document.getElementById("asf_stm_stop");
+                    stopButton.parentNode.removeChild(stopButton);
+                    return;
+                }
+                let status = xhr.status;
+                if (status === 200) {
+                    try {
+                        debugPrint("processing badge " + myBadges[index].appId);
+                        if (xhr.json.eresult == 1) {
+                            if (xhr.json.badgedata.rgCards.length >= 5) {
+                                errors = 0;
+                                myBadges[index].maxCards = xhr.json.badgedata.rgCards.length;
+                                for (let i = 0; i < myBadges[index].maxCards; i++) {
+                                    let newcard = {
+                                        item: xhr.json.badgedata.rgCards[i].name,
+                                        hash: xhr.json.badgedata.rgCards[i].markethash,
+                                        count: xhr.json.badgedata.rgCards[i].owned,
+                                        iconUrl: xhr.json.badgedata.rgCards[0].imgurl,
+                                        number: i
+                                    };
+                                    debugPrint(JSON.stringify(newcard));
+                                    myBadges[index].cards.push(newcard);
+                                    cardNames.add(xhr.json.badgedata.rgCards[i].markethash);
+                                }
+
+                                index++;
+                                setTimeout(
+                                    (function (index) {
+                                        return function () {
+                                            GetOwnCards(index);
+                                        };
+                                    })(index),
+                                    globalSettings.weblimiter,
+                                );
+                                return;
+                            } else {
+                                debugPrint("less than 5 cards in a badge - something is wrong")
+                                debugPrint(JSON.stringify(xhr.json));
+                                errors++;
+                            }
+                        } else {
+                            debugPrint("eresult = "+xhr.json.eresult);
+                            updateMessage("Error getting own badge data");
+                            hideThrobber();
+                            enableButton();
+                            let stopButton = document.getElementById("asf_stm_stop");
+                            stopButton.parentNode.removeChild(stopButton);
+                            return;
+                        }
+                    } catch (error) {
+                        debugPrint(error);
+                        debugPrint(JSON.stringify(xhr.json));
+                        errors++;
+                    }
+                } else {
+                    errors++;
+                }
+                if ((status < 400 || status >= 500) && errors <= globalSettings.maxErrors) {
+                    setTimeout(
+                        (function (index) {
+                            return function () {
+                                GetOwnCards(index);
+                            };
+                        })(index),
+                        globalSettings.weblimiter + globalSettings.errorLimiter * errors,
+                    );
+                } else {
+                    if (status !== 200) {
+                        updateMessage("Error getting badge data, ERROR " + status);
+                    } else {
+                        debugPrint("Error getting own badge data, wrong badge " + myBadges[index].appId);
+                        setTimeout(
+                            (function (index) {
+                                return function () {
+                                    GetOwnCards(index);
+                                };
+                            })(index),
+                            globalSettings.weblimiter + globalSettings.errorLimiter * errors,
+                        );
+                    }
+                    hideThrobber();
+                    enableButton();
+                    let stopButton = document.getElementById("asf_stm_stop");
+                    stopButton.parentNode.removeChild(stopButton);
+                    return;
+                }
+            };
+            // eslint-disable-next-line
+            xhr.onerror = function () {
+                if (stop) {
+                    updateMessage("Interrupted by user");
+                    hideThrobber();
+                    enableButton();
+                    let stopButton = document.getElementById("asf_stm_stop");
+                    stopButton.parentNode.removeChild(stopButton);
+                    return;
+                }
+                errors++;
+                if (errors <= globalSettings.maxErrors) {
+                    setTimeout(
+                        (function (index) {
+                            return function () {
+                                GetOwnCards(index);
+                            };
+                        })(index),
+                        globalSettings.weblimiter + globalSettings.errorLimiter * errors,
+                    );
+                    return;
+                } else {
+                    debugPrint("error");
+                    updateMessage("Error getting badge data");
+                    hideThrobber();
+                    enableButton();
+                    let stopButton = document.getElementById("asf_stm_stop");
+                    stopButton.parentNode.removeChild(stopButton);
+                    return;
+                }
+            };
+            xhr.send();
+            return; //do this synchronously to avoid rate limit
+        }
+        debugPrint("populated");
+
+        debugTime("Filter and sort");
+        for (let i = myBadges.length - 1; i >= 0; i--) {
+            debugPrint("badge " + i + JSON.stringify(myBadges[i]));
+
+            myBadges[i].cards.sort((a, b) => b.count - a.count);
+            if (myBadges[i].cards[0].count - myBadges[i].cards[myBadges[i].cards.length - 1].count < 2) {
+                //nothing to match, remove from list.
+                myBadges.splice(i, 1);
+                continue;
+            }
+
+            let totalCards = 0;
+            for (let j = 0; j < myBadges[i].maxCards; j++) {
+                totalCards += myBadges[i].cards[j].count;
+            }
+            myBadges[i].maxSets = Math.floor(totalCards / myBadges[i].maxCards);
+            myBadges[i].lastSet = Math.ceil(totalCards / myBadges[i].maxCards);
+            debugPrint("totalCards=" + totalCards + " maxSets=" + myBadges[i].maxSets + " lastSet=" + myBadges[i].lastSet);
+        }
+        debugTimeEnd("Filter and sort");
+
+        if (myBadges.length === 0) {
+            hideThrobber();
+            updateMessage("No cards to match");
+            enableButton();
+            let stopButton = document.getElementById("asf_stm_stop");
+                stopButton.parentNode.removeChild(stopButton);
+            return;
+        } else {
+            SaveParams();
+            GetCards(0, 0);
+            return;
+        }
+    }
+
+    function SortOwnCards() {
+    }
+
     function GetCards(index, userindex) {
         debugPrint("GetCards " + index + " : " + userindex);
 
@@ -919,13 +1106,11 @@
             return;
         }
 
-        if (
-            userindex >= 0 &&
-            ((bots.Result[userindex].MatchEverything && !globalSettings.anyBots) ||
-                (!bots.Result[userindex].MatchEverything && !globalSettings.fairBots) ||
-                bots.Result[userindex].TotalInventoryCount < globalSettings.botMinItems ||
-                (globalSettings.botMaxItems > 0 && bots.Result[userindex].TotalInventoryCount > globalSettings.botMaxItems) ||
-                blacklist.includes(bots.Result[userindex].SteamID))
+        if (((bots.Result[userindex].MatchEverything && !globalSettings.anyBots) ||
+            (!bots.Result[userindex].MatchEverything && !globalSettings.fairBots) ||
+             bots.Result[userindex].TotalInventoryCount < globalSettings.botMinItems ||
+             (globalSettings.botMaxItems > 0 && bots.Result[userindex].TotalInventoryCount > globalSettings.botMaxItems) ||
+             blacklist.includes(bots.Result[userindex].SteamID))
         ) {
             debugPrint("Ignoring bot " + bots.Result[userindex].SteamID);
             debugPrint(bots.Result[userindex].MatchEverything && !globalSettings.anyBots);
@@ -945,16 +1130,9 @@
             }
         }
         if (index < botBadges.length) {
-            let profileLink;
-            if (userindex === -1) {
-                profileLink = myProfileLink;
-                updateMessage("Getting our data for badge " + (index + 1) + " of " + botBadges.length);
-                updateProgress(index, botBadges.length);
-            } else {
-                profileLink = "profiles/" + bots.Result[userindex].SteamID;
-                updateMessage("Fetching bot " + (userindex + 1).toString() + " of " + bots.Result.length.toString() + " (badge " + (index + 1) + " of " + botBadges.length + ")");
-                updateProgress(userindex, bots.Result.length);
-            }
+            let profileLink = "profiles/" + bots.Result[userindex].SteamID;
+            updateMessage("Fetching bot " + (userindex + 1).toString() + " of " + bots.Result.length.toString() + " (badge " + (index + 1) + " of " + botBadges.length + ")");
+            updateProgress(userindex, bots.Result.length);
 
             let url = "https://steamcommunity.com/" + profileLink + "/gamecards/" + botBadges[index].appId;
             let xhr = new XMLHttpRequest();
@@ -1000,33 +1178,16 @@
                                 }
                             });
                             name = name.trim();
+                            let markethash = myBadges[index].cards.find(card => card.number === i).hash;
                             let icon = badgeCards[i].querySelector(".gamecard").src.trim();
                             let newcard = {
                                 item: name,
+                                hash: markethash,
                                 count: Number(quantity),
                                 iconUrl: icon,
                             };
                             debugPrint(JSON.stringify(newcard));
                             botBadges[index].cards.push(newcard);
-                            if (userindex === -1) {
-                                //maybe save whole hash with .split("/")[5] ?
-                                cardNames.add(icon.substring(icon.length - 5) + "." + botBadges[index].appId + "-" + name);
-                            }
-                        }
-
-                        //Check for same hash but different name, ask user to report
-                        if (userindex === -1) {
-                            for (let j = 0; j < botBadges[index].cards.length; j++) {
-                                for (let i = 0; i < botBadges[index].cards.length; i++) {
-                                    if (
-                                        i !== j &&
-                                        botBadges[index].cards[i].name !== botBadges[index].cards[j].name &&
-                                        botBadges[index].cards[j].iconUrl.substring(botBadges[index].cards[j].iconUrl.length - 5) === botBadges[index].cards[i].iconUrl.substring(botBadges[index].cards[i].iconUrl.length - 5)
-                                    ) {
-                                        unsafeWindow.ShowAlertDialog("WARNING", "Different cards have same signature, please report this: " + botBadges[index].appId);
-                                    }
-                                }
-                            }
                         }
 
                         index++;
@@ -1118,13 +1279,6 @@
             debugPrint("badge " + i + JSON.stringify(botBadges[i]));
 
             botBadges[i].cards.sort((a, b) => b.count - a.count);
-            if (userindex < 0) {
-                if (botBadges[i].cards[0].count - botBadges[i].cards[botBadges[i].cards.length - 1].count < 2) {
-                    //nothing to match, remove from list.
-                    botBadges.splice(i, 1);
-                    continue;
-                }
-            }
             let totalCards = 0;
             for (let j = 0; j < botBadges[i].maxCards; j++) {
                 totalCards += botBadges[i].cards[j].count;
@@ -1135,33 +1289,18 @@
         }
         debugTimeEnd("Filter and sort");
 
-        if (userindex < 0) {
-            if (botBadges.length === 0) {
-                hideThrobber();
-                updateMessage("No cards to match");
-                enableButton();
-                let stopButton = document.getElementById("asf_stm_stop");
-                stopButton.parentNode.removeChild(stopButton);
-                return;
-            } else {
-                SaveParams();
-                myBadges = deepClone(botBadges);
-                GetCards(0, 0);
-                return;
-            }
-        } else {
-            debugPrint(bots.Result[userindex].SteamID);
-            compareCards(userindex, function () {
-                setTimeout(
-                    (function (userindex) {
-                        return function () {
-                            GetCards(0, userindex);
-                        };
-                    })(userindex + 1),
-                    globalSettings.weblimiter,
-                );
-            });
-        }
+        debugPrint(bots.Result[userindex].SteamID);
+        compareCards(userindex, function () {
+            setTimeout(
+                (function (userindex) {
+                    return function () {
+                        GetCards(0, userindex);
+                    };
+                })(userindex + 1),
+                globalSettings.weblimiter,
+            );
+        });
+
     }
 
     function getBadges(page) {
@@ -1250,7 +1389,7 @@
                     } else {
                         setTimeout(
                             function () {
-                                GetCards(0, -1);
+                                GetOwnCards(0);
                             },
                             globalSettings.weblimiter + globalSettings.errorLimiter * errors,
                         );
@@ -1484,6 +1623,9 @@
         requestFunc({
             method: "GET",
             url: requestUrl,
+            headers: {
+                "User-Agent": "ASF-STM/" + GM_info.version
+            },
             onload: function (response) {
                 if (response.status !== 200) {
                     disableButton();


### PR DESCRIPTION
## Changes
 - Uses `/ajaxgetbadgeinfo/` API endpoint for getting own badges - this allows to get market hash of cards.
 - cards are matched by card number instead of card name - in case `/ajaxgetbadgeinfo/` and badge pages return different names.
 - Use market hash to fill trade offers - should solve issues like #22 
 - Added custom user-agent header to requests to ASFB - for statistics tracking.
 
Needs extensive testing before merging. If anyone wants to help testing - installation link is [here](https://github.com/Rudokhvist/ASF-STM/raw/ajax/ASF-STM.user.js)
 
 

