### PR TITLE
Add filter button for each match row

### DIFF
--- a/ASF-STM.user.js
+++ b/ASF-STM.user.js
@@ -550,6 +550,17 @@
         });
     }
 
+    function filterAllEventHandler(event) {
+        let appIds = event.target.name.split(',');
+        appIds = appIds.map(id => 'astm_' + id);
+        for(let appId of appIds) {
+            let target = document.querySelector('#' + appId);
+            if (target && target.checked) {
+                target.click();
+            }
+        }
+    }
+
     function populateCards(item) {
         let htmlCards = "";
         for (let j = 0; j < item.cards.length; j++) {
@@ -613,11 +624,13 @@
 
         let matches = "";
         let any = "";
+        let appIdList = [];
         if (bots.Result[index].MatchEverything) {
             any = `&nbsp;<sup><span class="avatar_block_status_in-game" style="font-size: 8px; cursor:help" title="This bots trades for any cards within same set">&nbsp;ANY&nbsp;</span></sup>`;
         }
         for (let i = 0; i < itemsToSend.length; i++) {
             let appId = itemsToSend[i].appId;
+            appIdList.push(appId);
             let itemToReceive = itemsToReceive.find((a) => a.appId == appId);
             let gameName = itemsToSend[i].title;
             let display = "inline-block";
@@ -695,6 +708,11 @@
                   <div class="badge_title_stats">
                     <div class="btn_darkblue_white_innerfade btn_medium">
                       <span>
+                        <a class="filter_all" name="${appIdList.join()}" target="_blank" rel="noopener noreferrer" >Filter All</a>
+                      </span>
+                    </div>
+                    <div class="btn_darkblue_white_innerfade btn_medium">
+                      <span>
                         <a class="full_trade_url" href="${tradeUrlFull}" target="_blank" rel="noopener noreferrer" >Offer a trade for all</a>
                       </span>
                     </div>
@@ -723,6 +741,7 @@
         let mainContentDiv = document.getElementsByClassName("maincontent")[0];
         let newChild = template.content.firstChild;
         newChild.querySelector(`#blacklist_${bots.Result[index].SteamID}`).addEventListener("click", blacklistEventHandler, true);
+        newChild.querySelector('.filter_all').parentNode.addEventListener('click', filterAllEventHandler);
         mainContentDiv.appendChild(newChild);
         checkRow(newChild);
     }


### PR DESCRIPTION
Filter all apps from a match row. Useful when you want to quickly filter the apps from a trade you just sent.

Clicking the `Filter All` button will hide visible apps.

### Before button click
![before](https://github.com/Rudokhvist/ASF-STM/assets/1362764/bbf745aa-6a72-45b3-b8e0-cdaa9404a468)

### After button click
![after](https://github.com/Rudokhvist/ASF-STM/assets/1362764/127b57d3-3098-4725-972b-db17be9dda30)